### PR TITLE
Modify constructor signature

### DIFF
--- a/Whois.php
+++ b/Whois.php
@@ -137,7 +137,7 @@ class Net_Whois extends PEAR
      *
      * @access public
      */
-    function Net_Whois()
+    function __construct()
     {
         $this->PEAR();
 


### PR DESCRIPTION
To resolve the following exception in PHP 7.2:

"Methods with the same name as their class will not be constructors in a future version of PHP; Net_Whois has a deprecated constructor."